### PR TITLE
Handle slashes in branch names

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -124,7 +124,10 @@ Create new branches using
 	if err != nil {
 		return fmt.Errorf("failed to get current branch: %w", err)
 	}
-	err = git.AddWorktree(cloneDir, currentBranch)
+	err = git.AddWorktree(git.AddWorktreeArgs{
+		Dir:          cloneDir,
+		WorktreePath: currentBranch, // TODO: handle slashes in branch name
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create initial worktree: %w", err)
 	}

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -124,10 +124,7 @@ Create new branches using
 	if err != nil {
 		return fmt.Errorf("failed to get current branch: %w", err)
 	}
-	err = git.AddWorktree(git.AddWorktreeArgs{
-		Dir:          cloneDir,
-		WorktreePath: currentBranch, // TODO: handle slashes in branch name
-	})
+	err = common.AddWorktree(cloneDir, currentBranch)
 	if err != nil {
 		return fmt.Errorf("failed to create initial worktree: %w", err)
 	}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -46,30 +46,8 @@ func New(cmd *cobra.Command, args []string) error {
 }
 
 func newWorktreeBasedOnExistingBranch(branch string) error {
-	repoBasePath, err := common.RepoBasePath()
-	if err != nil {
-		return fmt.Errorf("couldn't get repo base path: %w", err)
-	}
-
 	fmt.Printf("creating new worktree based on existing local branch %q\n", branch)
-
-	worktreePath := worktreePathForBranchName(branch)
-	if worktreePath != branch {
-		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", branch, worktreePath)
-	}
-
-	err = git.AddWorktree(git.AddWorktreeArgs{
-		Dir:          repoBasePath,
-		WorktreePath: worktreePath,
-		Branch:       branch,
-	})
-	if err != nil {
-		return fmt.Errorf("couldn't create worktree for branch %q: %w", branch, err)
-	}
-
-	// We can't set the upstream branch yet, as it doesn't yet exist. We have
-	// to wait until push time to do this.
-	return nil
+	return common.AddWorktree("", branch)
 }
 
 func newWorktreeNewBranchWithBase(newBranch, base string) error {
@@ -81,28 +59,7 @@ func newWorktreeNewBranchWithBase(newBranch, base string) error {
 		return fmt.Errorf("couldn't create branch %q: %w", newBranch, err)
 	}
 
-	repoBasePath, err := common.RepoBasePath()
-	if err != nil {
-		return fmt.Errorf("couldn't get repo base path: %w", err)
-	}
-
-	worktreePath := worktreePathForBranchName(newBranch)
-	if worktreePath != newBranch {
-		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", newBranch, worktreePath)
-	}
-
-	err = git.AddWorktree(git.AddWorktreeArgs{
-		Dir:          repoBasePath,
-		WorktreePath: worktreePath,
-		Branch:       newBranch,
-	})
-	if err != nil {
-		return fmt.Errorf("couldn't create worktree for branch %q: %w", newBranch, err)
-	}
-
-	// We can't set the upstream branch yet, as it doesn't yet exist. We have
-	// to wait until push time to do this.
-	return nil
+	return common.AddWorktree("", newBranch)
 }
 
 func newWorktreeBasedOnRemoteBranch(remote, branch string) error {
@@ -138,24 +95,5 @@ func newWorktreeBasedOnRemoteBranch(remote, branch string) error {
 		return fmt.Errorf("couldn't create branch %q: %w", branch, err)
 	}
 
-	worktreePath := worktreePathForBranchName(branch)
-	if worktreePath != branch {
-		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", branch, worktreePath)
-	}
-
-	err = git.AddWorktree(git.AddWorktreeArgs{
-		Dir:          repoBasePath,
-		WorktreePath: worktreePath,
-		Branch:       branch,
-	})
-	if err != nil {
-		return fmt.Errorf("couldn't create worktree for branch %q: %w", branch, err)
-	}
-	return nil
-}
-
-// If a branch name contains slashes, the corresponding worktree path should
-// have them replaced with underscores.
-func worktreePathForBranchName(branchName string) string {
-	return strings.ReplaceAll(branchName, "/", "_")
+	return common.AddWorktree("", branch)
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -52,7 +52,17 @@ func newWorktreeBasedOnExistingBranch(branch string) error {
 	}
 
 	fmt.Printf("creating new worktree based on existing local branch %q\n", branch)
-	err = git.AddWorktree(repoBasePath, branch)
+
+	worktreePath := worktreePathForBranchName(branch)
+	if worktreePath != branch {
+		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", branch, worktreePath)
+	}
+
+	err = git.AddWorktree(git.AddWorktreeArgs{
+		Dir:          repoBasePath,
+		WorktreePath: worktreePath,
+		Branch:       branch,
+	})
 	if err != nil {
 		return fmt.Errorf("couldn't create worktree for branch %q: %w", branch, err)
 	}
@@ -63,6 +73,8 @@ func newWorktreeBasedOnExistingBranch(branch string) error {
 }
 
 func newWorktreeNewBranchWithBase(newBranch, base string) error {
+	/// TODO: pull base branch
+
 	fmt.Printf("creating new branch %q based on %q\n", newBranch, base)
 	err := git.CreateBranch(newBranch, base)
 	if err != nil {
@@ -73,7 +85,17 @@ func newWorktreeNewBranchWithBase(newBranch, base string) error {
 	if err != nil {
 		return fmt.Errorf("couldn't get repo base path: %w", err)
 	}
-	err = git.AddWorktree(repoBasePath, newBranch)
+
+	worktreePath := worktreePathForBranchName(newBranch)
+	if worktreePath != newBranch {
+		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", newBranch, worktreePath)
+	}
+
+	err = git.AddWorktree(git.AddWorktreeArgs{
+		Dir:          repoBasePath,
+		WorktreePath: worktreePath,
+		Branch:       newBranch,
+	})
 	if err != nil {
 		return fmt.Errorf("couldn't create worktree for branch %q: %w", newBranch, err)
 	}
@@ -116,9 +138,24 @@ func newWorktreeBasedOnRemoteBranch(remote, branch string) error {
 		return fmt.Errorf("couldn't create branch %q: %w", branch, err)
 	}
 
-	err = git.AddWorktree(repoBasePath, branch)
+	worktreePath := worktreePathForBranchName(branch)
+	if worktreePath != branch {
+		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", branch, worktreePath)
+	}
+
+	err = git.AddWorktree(git.AddWorktreeArgs{
+		Dir:          repoBasePath,
+		WorktreePath: worktreePath,
+		Branch:       branch,
+	})
 	if err != nil {
 		return fmt.Errorf("couldn't create worktree for branch %q: %w", branch, err)
 	}
 	return nil
+}
+
+// If a branch name contains slashes, the corresponding worktree path should
+// have them replaced with underscores.
+func worktreePathForBranchName(branchName string) string {
+	return strings.ReplaceAll(branchName, "/", "_")
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -51,10 +51,14 @@ func newWorktreeBasedOnExistingBranch(branch string) error {
 }
 
 func newWorktreeNewBranchWithBase(newBranch, base string) error {
-	/// TODO: pull base branch
+	fmt.Printf("Pulling branch %q...\n", base)
+	err := pull(base)
+	if err != nil {
+		return err
+	}
 
 	fmt.Printf("creating new branch %q based on %q\n", newBranch, base)
-	err := git.CreateBranch(newBranch, base)
+	err = git.CreateBranch(newBranch, base)
 	if err != nil {
 		return fmt.Errorf("couldn't create branch %q: %w", newBranch, err)
 	}

--- a/common/git/git.go
+++ b/common/git/git.go
@@ -41,9 +41,6 @@ func Clone(opts CloneArgs) error {
 	return err
 }
 
-// git worktree add <path>   - creates or checks out branch base(path)
-// git worktree add <path> <branch>
-
 type AddWorktreeArgs struct {
 	Dir          string // directory to run the command in
 	WorktreePath string // path for the new worktree

--- a/common/git/git.go
+++ b/common/git/git.go
@@ -41,8 +41,21 @@ func Clone(opts CloneArgs) error {
 	return err
 }
 
-func AddWorktree(dir, name string) error {
-	_, err := internalExec(dir, "worktree", "add", name)
+// git worktree add <path>   - creates or checks out branch base(path)
+// git worktree add <path> <branch>
+
+type AddWorktreeArgs struct {
+	Dir          string // directory to run the command in
+	WorktreePath string // path for the new worktree
+	Branch       string // branch to check out in the new worktree (optional)
+}
+
+func AddWorktree(opts AddWorktreeArgs) error {
+	args := []string{"worktree", "add", opts.WorktreePath}
+	if opts.Branch != "" {
+		args = append(args, opts.Branch)
+	}
+	_, err := internalExec(opts.Dir, args...)
 	return err
 }
 

--- a/common/worktree.go
+++ b/common/worktree.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"fmt"
+	"github.com/barrettj12/jit/common/git"
+	"strings"
+)
+
+// AddWorktree adds a worktree for the given branch. It assumes the branch
+// already exists and is ready to be checked out.
+func AddWorktree(repoBasePath, branch string) error {
+	// If a branch name contains slashes, the corresponding worktree path
+	// should have them replaced with underscores.
+	worktreePath := strings.ReplaceAll(branch, "/", "_")
+	if worktreePath != branch {
+		fmt.Printf("WARNING branch name %q contains slashes, worktree path will be %q instead", branch, worktreePath)
+	}
+
+	if repoBasePath == "" {
+		var err error
+		repoBasePath, err = RepoBasePath()
+		if err != nil {
+			return fmt.Errorf("couldn't get repo base path: %w", err)
+		}
+	}
+
+	err := git.AddWorktree(git.AddWorktreeArgs{
+		Dir:          repoBasePath,
+		WorktreePath: worktreePath,
+		Branch:       branch,
+	})
+	if err != nil {
+		return fmt.Errorf("couldn't create worktree for branch %q: %w", branch, err)
+	}
+	return nil
+}

--- a/test/tests/new.sh
+++ b/test/tests/new.sh
@@ -6,6 +6,7 @@ setup_test_repo new/repo1
 jit clone new/repo1 --fork=false
 cd $JIT_DIR/new/repo1
 
+
 # Test creating new branch based on existing branch
 git branch branch1 main
 jit new branch1
@@ -14,12 +15,21 @@ cd branch1
 git branch | grep '* branch1'
 cd ..
 
+
 # Test creating new worktree from existing local branch
+# First add a commit to the remote's 'main' branch - we want to check the local
+# 'main' branch is updated before the new branch is created.
+echo "goodbye cruel world" > "$GIT_PROJECT_ROOT/new/repo1/bar.txt"
+git -C "$GIT_PROJECT_ROOT/new/repo1" add bar.txt
+git -C "$GIT_PROJECT_ROOT/new/repo1" commit -m "remote file added"
+# Create the new branch
 jit new branch2 main
 cd branch2
 # shellcheck disable=SC2063
 git branch | grep '* branch2'
+git log | grep 'remote file added'
 cd ..
+
 
 # Test creating new worktree from existing remote branch
 # Clone the test repo
@@ -34,6 +44,7 @@ git branch | grep '* branch3'
 git rev-parse --abbrev-ref 'branch3@{u}' | grep 'new2/branch3'
 git rev-parse --abbrev-ref 'branch3@{push}' | grep 'new2/branch3'
 cd ..
+
 
 # Check that branch names containing a slash '/' are supported
 # Regression test for https://github.com/barrettj12/jit/issues/6

--- a/test/tests/new.sh
+++ b/test/tests/new.sh
@@ -34,3 +34,12 @@ git branch | grep '* branch3'
 git rev-parse --abbrev-ref 'branch3@{u}' | grep 'new2/branch3'
 git rev-parse --abbrev-ref 'branch3@{push}' | grep 'new2/branch3'
 cd ..
+
+# Check that branch names containing a slash '/' are supported
+# Regression test for https://github.com/barrettj12/jit/issues/6
+git branch 'branch/with/slashes' main
+jit new 'branch/with/slashes'
+cd 'branch_with_slashes'
+# shellcheck disable=SC2063
+git branch | grep '* branch/with/slashes'
+cd ..


### PR DESCRIPTION
If a branch name has slashes, the corresponding worktree path with have them replaced with underscores.

Fixes #6