### PR TITLE
improve error message from git.AddWorktree when branch doesn't exist

### DIFF
--- a/common/git/errors.go
+++ b/common/git/errors.go
@@ -6,14 +6,21 @@ import (
 )
 
 func IsNoSuchRemoteErr(err error) bool {
-	return strings.Contains(err.Error(), "error: No such remote ")
+	return err != nil && strings.Contains(err.Error(), "error: No such remote ")
 }
 
 func IsRemoteAlreadyExistsErr(err error) bool {
+	if err == nil {
+		return false
+	}
 	match, _ := regexp.MatchString("remote .* already exists", err.Error())
 	return match
 }
 
 func IsNoUpstreamConfiguredErr(err error) bool {
-	return strings.Contains(err.Error(), "fatal: no upstream configured for branch ")
+	return err != nil && strings.Contains(err.Error(), "fatal: no upstream configured for branch ")
+}
+
+func IsNoSuchBranchErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "invalid reference:")
 }

--- a/common/git/git_test.go
+++ b/common/git/git_test.go
@@ -3,6 +3,7 @@ package git_test
 import (
 	"github.com/barrettj12/jit/common/git"
 	"github.com/barrettj12/jit/common/testutil"
+	"path/filepath"
 	"testing"
 )
 
@@ -16,4 +17,17 @@ func TestRemoteExists(t *testing.T) {
 	remoteExists, err = git.RemoteExists(repoPath, "myremote")
 	testutil.CheckErr(t, err)
 	testutil.AssertEqual(t, remoteExists, true)
+}
+
+// Check that if a branch doesn't exist, git.AddWorktree returns a helpful
+// error.
+func TestAddWorktreeBranchDoesntExist(t *testing.T) {
+	repoPath := testutil.SetupTestRepo(t, "")
+	err := git.AddWorktree(git.AddWorktreeArgs{
+		Branch:       "mybranch",
+		WorktreePath: filepath.Join(repoPath, "mybranch"),
+		Dir:          repoPath,
+	})
+	testutil.AssertNotEqual(t, err, nil)
+	testutil.AssertEqual(t, err.Error(), `branch "mybranch" doesn't exist`)
 }

--- a/common/git/worktree.go
+++ b/common/git/worktree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -19,6 +20,9 @@ func AddWorktree(opts AddWorktreeArgs) error {
 		args: args,
 		dir:  opts.Dir,
 	})
+	if IsNoSuchBranchErr(err) {
+		return fmt.Errorf("branch %q doesn't exist", opts.Branch)
+	}
 	return err
 }
 

--- a/common/testutil/util.go
+++ b/common/testutil/util.go
@@ -30,3 +30,9 @@ func AssertEqual[T comparable](t *testing.T, obtained, expected T) {
 		t.Fatalf("obtained %#v, expected %#v", obtained, expected)
 	}
 }
+
+func AssertNotEqual[T comparable](t *testing.T, obtained, expected T) {
+	if obtained == expected {
+		t.Fatalf("obtained and expected are equal = %#v", expected)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/barrettj12/jit
 
-go 1.19
+go 1.22
 
 require github.com/spf13/cobra v1.8.1
 


### PR DESCRIPTION
- update go mod to 1.22

closes #30