### PR TITLE
Add squash and rebase commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ Remove a given branch/worktree and its upstream remote.
 jit rm <branch>
 ```
 
+### `jit squash`
+Squash all commits in the current branch into one. Requires a GitHub PR to be
+open on the branch.
+
+### `jit rebase`
+Rebase the current branch against the latest version of the base branch.
+Requires a GitHub PR to be open on the branch.
+
 <!--
 TODO: restore this section once hooks are implemented
 

--- a/cmd/all.go
+++ b/cmd/all.go
@@ -15,7 +15,10 @@ func AddSubcommands(baseCmd *cobra.Command) {
 		publishCmd,
 		pullCmd,
 		pushCmd,
+		rebaseCmd,
 		removeCmd,
+		squashCmd,
+		squashEditorCmd,
 		whatCmd,
 		whereCmd,
 	)

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/barrettj12/jit/common"
+	"github.com/barrettj12/jit/common/gh"
+	"github.com/barrettj12/jit/common/git"
+	"github.com/spf13/cobra"
+)
+
+var rebaseCmd = &cobra.Command{
+	Use:   "rebase",
+	Short: "Rebase against the latest version of the target branch",
+	RunE:  Rebase,
+}
+
+func Rebase(cmd *cobra.Command, args []string) error {
+	prInfo, err := gh.GetPRInfo("")
+	if err != nil {
+		return fmt.Errorf("getting pull request for current branch: %w", err)
+	}
+
+	// Pull base branch
+	base := prInfo.BaseBranch
+	fmt.Printf("Pulling branch %q...\n", base)
+	err = common.Pull(base)
+	if err != nil {
+		return fmt.Errorf("pulling branch %q: %w", base, err)
+	}
+
+	fmt.Printf("Rebasing against latest version of %q...\n", base)
+	err = git.Rebase(git.RebaseArgs{
+		Base:        base,
+		Interactive: false,
+	})
+	if err != nil {
+		return fmt.Errorf("rebasing: %w", err)
+	}
+
+	fmt.Println("Successfully rebased")
+	return nil
+}

--- a/cmd/squash.go
+++ b/cmd/squash.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/barrettj12/jit/common/gh"
+	"github.com/barrettj12/jit/common/git"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+var squashCmd = &cobra.Command{
+	Use:   "squash",
+	Short: "Squash all commits on a branch",
+	RunE:  Squash,
+}
+
+func Squash(cmd *cobra.Command, args []string) error {
+	prInfo, err := gh.GetPRInfo("")
+	if err != nil {
+		return fmt.Errorf("getting pull request for current branch: %w", err)
+	}
+
+	// Find base commit to rebase against
+	mergeBase, err := git.MergeBase("HEAD", prInfo.BaseBranch)
+	if err != nil {
+		return fmt.Errorf("finding merge base: %w", err)
+	}
+
+	fmt.Printf("squashing against %q commit %s...\n", prInfo.BaseBranch, mergeBase[:10])
+	err = git.Rebase(git.RebaseArgs{
+		Base:        mergeBase,
+		Interactive: true,
+		Env:         []string{"GIT_SEQUENCE_EDITOR=jit squash-editor"},
+	})
+	if err != nil {
+		return fmt.Errorf("rebasing: %w", err)
+	}
+
+	fmt.Println("successfully squashed")
+	return nil
+}
+
+var squashEditorCmd = &cobra.Command{
+	Use:    "squash-editor",
+	Hidden: true,
+	RunE:   SquashEditor,
+}
+
+func SquashEditor(cmd *cobra.Command, args []string) error {
+	filename := args[0]
+
+	fileContents, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("reading file %q: %w", filename, err)
+	}
+	lines := strings.Split(string(fileContents), "\n")
+
+	file, err := os.Create(filename)
+	defer file.Close()
+	if err != nil {
+		return fmt.Errorf("opening file %q: %w", filename, err)
+	}
+
+	// First line (commit) unchanged
+	_, err = file.WriteString(lines[0] + "\n")
+	if err != nil {
+		return fmt.Errorf("writing to file %q: %w", filename, err)
+	}
+
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(line, "pick ") {
+			cutLine, _ := strings.CutPrefix(line, "pick ")
+			line = "f " + cutLine
+		}
+
+		_, err = file.WriteString(line + "\n")
+		if err != nil {
+			return fmt.Errorf("writing to file %q: %w", filename, err)
+		}
+	}
+	return nil
+}

--- a/cmd/squash_test.go
+++ b/cmd/squash_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"github.com/barrettj12/jit/common/testutil"
+	"os"
+	"testing"
+)
+
+func TestSquashEditor(t *testing.T) {
+	// Set up rebase to-do file
+	file, err := os.CreateTemp("", "git-rebase-todo")
+	testutil.CheckErr(t, err)
+	t.Cleanup(func() {
+		err = os.Remove(file.Name())
+		testutil.CheckErr(t, err)
+	})
+
+	_, err = file.WriteString(squashFileBefore)
+	testutil.CheckErr(t, err)
+	err = file.Close()
+	testutil.CheckErr(t, err)
+
+	err = SquashEditor(nil, []string{file.Name()})
+	testutil.CheckErr(t, err)
+	fileContents, err := os.ReadFile(file.Name())
+	testutil.AssertEqual(t, string(fileContents), squashFileAfter)
+}
+
+var squashFileBefore = `
+pick bd64edd commit message 1
+pick 86304e9 commit message 2
+pick dab68cf commit message 3
+pick 0c4ebf0 commit message 4
+
+# Rebase a422b17..0c4ebf0 onto a422b17 (4 commands)
+#
+# Commands:
+# p, pick <commit> = use commit
+# r, reword <commit> = use commit, but edit the commit message
+# e, edit <commit> = use commit, but stop for amending
+# s, squash <commit> = use commit, but meld into previous commit
+# f, fixup [-C | -c] <commit> = like "squash" but keep only the previous
+#                    commit's log message, unless -C is used, in which case
+#                    keep only this commit's message; -c is same as -C but
+#                    opens the editor
+# x, exec <command> = run command (the rest of the line) using shell
+# b, break = stop here (continue rebase later with 'git rebase --continue')
+# d, drop <commit> = remove commit
+# l, label <label> = label current HEAD with a name
+# t, reset <label> = reset HEAD to a label
+# m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
+#         create a merge commit using the original merge commit's
+#         message (or the oneline, if no original merge commit was
+#         specified); use -c <commit> to reword the commit message
+# u, update-ref <ref> = track a placeholder for the <ref> to be updated
+#                       to this position in the new commits. The <ref> is
+#                       updated at the end of the rebase
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# If you remove a line here THAT COMMIT WILL BE LOST.
+#
+# However, if you remove everything, the rebase will be aborted.
+#
+`[1:]
+
+var squashFileAfter = `
+pick bd64edd commit message 1
+f 86304e9 commit message 2
+f dab68cf commit message 3
+f 0c4ebf0 commit message 4
+
+# Rebase a422b17..0c4ebf0 onto a422b17 (4 commands)
+#
+# Commands:
+# p, pick <commit> = use commit
+# r, reword <commit> = use commit, but edit the commit message
+# e, edit <commit> = use commit, but stop for amending
+# s, squash <commit> = use commit, but meld into previous commit
+# f, fixup [-C | -c] <commit> = like "squash" but keep only the previous
+#                    commit's log message, unless -C is used, in which case
+#                    keep only this commit's message; -c is same as -C but
+#                    opens the editor
+# x, exec <command> = run command (the rest of the line) using shell
+# b, break = stop here (continue rebase later with 'git rebase --continue')
+# d, drop <commit> = remove commit
+# l, label <label> = label current HEAD with a name
+# t, reset <label> = reset HEAD to a label
+# m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
+#         create a merge commit using the original merge commit's
+#         message (or the oneline, if no original merge commit was
+#         specified); use -c <commit> to reword the commit message
+# u, update-ref <ref> = track a placeholder for the <ref> to be updated
+#                       to this position in the new commits. The <ref> is
+#                       updated at the end of the rebase
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# If you remove a line here THAT COMMIT WILL BE LOST.
+#
+# However, if you remove everything, the rebase will be aborted.
+#
+
+`[1:]

--- a/common/gh/gh.go
+++ b/common/gh/gh.go
@@ -1,0 +1,40 @@
+package gh
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// PRInfo represents information about a pull request on GitHub
+type PRInfo struct {
+	BaseBranch string `json:"baseRefName"` // the branch the PR is targeting
+}
+
+// GetPRInfo returns information about a pull request based on the given branch.
+func GetPRInfo(branch string) (PRInfo, error) {
+	cmd := exec.Command("gh", "pr", "view", branch, "--json", "baseRefName")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	var runErr error
+	runErr = cmd.Run() // this error contains the exit code
+
+	// handle errors
+	if runErr != nil {
+		// Read stderr for error info
+		errInfo := stderr.String()
+		return PRInfo{}, fmt.Errorf("%s\n%w", errInfo, runErr)
+	}
+
+	// Unmarshal response to json
+	result := PRInfo{}
+	err := json.Unmarshal(stdout.Bytes(), &result)
+	if err != nil {
+		return PRInfo{}, fmt.Errorf("processing json response: %w", err)
+	}
+	return result, nil
+}

--- a/test/gh/main.go
+++ b/test/gh/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+// Mock implementation of gh. It just prints whatever is in the file pointed to
+// by the GH_RESPONSE environment variable.
+func main() {
+	filename := os.Getenv("GH_RESPONSE")
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Fatalf("opening file %q: %v", filename, err)
+	}
+	defer file.Close()
+
+	_, err = io.Copy(os.Stdout, file)
+	if err != nil {
+		log.Fatalf("writing response: %v", err)
+	}
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -11,6 +11,7 @@ RUN_TEST_SPEC=$1
 go build -buildvcs=false -o test/_build/jit .
 go build -buildvcs=false -o test/_build/gitserver ./test/gitserver
 go build -buildvcs=false -o test/_build/goland ./test/goland
+go build -buildvcs=false -o test/_build/gh ./test/gh
 
 IMAGE_NAME='jit-test'
 CONTAINER_NAME='jit-test'

--- a/test/tests/rebase.sh
+++ b/test/tests/rebase.sh
@@ -1,0 +1,33 @@
+# Test `jit rebase` command
+set -ex
+
+setup_test_repo rebase/repo1
+jit clone rebase/repo1 --fork=false
+cd $JIT_DIR/rebase/repo1
+
+# Create new branch
+jit new branch1 main
+cd branch1
+# Add commits to branch
+add_commit 'new.txt'
+# Add commits to remote branch
+add_remote_commit rebase/repo1 'base1.txt'
+add_remote_commit rebase/repo1 'base2.txt'
+add_remote_commit rebase/repo1 'base3.txt'
+
+# Set up mock response from gh
+export GH_RESPONSE='/home/ubuntu/gh-response'
+echo '{"baseRefName": "main"}' > $GH_RESPONSE
+
+# Rebase
+jit rebase
+# Check commits are in the correct order in the git log
+git show -s --oneline HEAD | grep 'new.txt'
+git show -s --oneline HEAD~1 | grep 'base3.txt'
+git show -s --oneline HEAD~2 | grep 'base2.txt'
+git show -s --oneline HEAD~3 | grep 'base1.txt'
+
+# Cleanup
+rm -rf $GIT_PROJECT_ROOT/rebase
+rm -rf $JIT_DIR/rebase
+rm -rf $GH_RESPONSE

--- a/test/tests/squash.sh
+++ b/test/tests/squash.sh
@@ -1,0 +1,34 @@
+# Test `jit squash` command
+set -ex
+
+setup_test_repo squash/repo1
+jit clone squash/repo1 --fork=false
+cd $JIT_DIR/squash/repo1
+
+# Create new branch
+jit new branch1 main
+cd branch1
+# Add commits to branch
+add_commit '1.txt'
+add_commit '2.txt'
+add_commit '3.txt'
+add_commit '4.txt'
+
+# Set up mock response from gh
+export GH_RESPONSE='/home/ubuntu/gh-response'
+echo '{"baseRefName": "main"}' > $GH_RESPONSE
+
+# Squash commits
+jit squash
+# Check squashed commit contains all files
+git diff --name-only HEAD HEAD~1 | grep '1.txt'
+git diff --name-only HEAD HEAD~1 | grep '2.txt'
+git diff --name-only HEAD HEAD~1 | grep '3.txt'
+git diff --name-only HEAD HEAD~1 | grep '4.txt'
+# Check there's only one commit on top of main
+[[ $(git log main..HEAD --oneline | wc -l) == 1 ]];
+
+# Cleanup
+rm -rf $GIT_PROJECT_ROOT/squash
+rm -rf $JIT_DIR/squash
+rm -rf $GH_RESPONSE


### PR DESCRIPTION
Closes #25

`squash` squashes all commits on the current branch into one
`rebase` pulls the latest version of the base branch and rebases against it

Both have to check GitHub for an open PR. I've added a `gh` package to handle calls to the GitHub CLI.

In testing, we're using a fake `gh` binary. I tried using the real `gh` and mocking out the GitHub API, but since it's HTTPS it was too difficult with all the certificate stuff.